### PR TITLE
Fix twitter account link of Johannes

### DIFF
--- a/team/Members/index.js
+++ b/team/Members/index.js
@@ -26,7 +26,7 @@ export const Members = () => {
               'Johannes is a Berlin/SF-based entrepreneur  and founder of Prisma, a flexible backend platform combining GraphQL+ AWS Lambda. He previously built and sold the VR company “Optonaut”. Johannes studied computer science at KIT, Germany and loves cutting- edge mobile/web tech-nologies.'
             }
             photoSrc="/static/team/johannes-schickling.jpg"
-            twitter="_schickling"
+            twitter="schickling"
             github="schickling"
           />
         </GridItem>


### PR DESCRIPTION
Current url returns a 404 -> looks like his twitter account is without the underscore
```
curl -I https://twitter.com/_schickling # => HTTP/2 404
curl -I https://twitter.com/schickling # => HTTP/2 200
```